### PR TITLE
添加目录标题并用分隔符包裹

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,6 +63,12 @@ const buildDocToc = (docId, lute, callback) => {
             return toc;
         }
         let tocs = iterate(ans);
+        
+        // 在开头加上 --- \n > # 目录 \n
+        tocs.unshift('--- \n > # 目录');
+        // 在结尾加上 ---
+        tocs.push('---');
+        
         tocs.push(`{: ${TOC_ATTR_NAME}="true" }`);
         callback(tocs);
     });

--- a/index.js
+++ b/index.js
@@ -99,10 +99,9 @@ const buildDocToc = (docId, lute, callback) => {
 
         // 在开头加上 --- \n > # 目录 \n
         tocs.unshift('--- \n > # 目录');
-
+        tocs.push(`{: ${TOC_ATTR_NAME}="true" }`);
         // 在结尾加上 ---
         tocs.push('---');
-        tocs.push(`{: ${TOC_ATTR_NAME}="true" }`);
         callback(tocs);
     });
 }


### PR DESCRIPTION
在原基础上给目录整体添加了标题, 使目录更加美观,清洗可见
<img width="229" alt="截图-PC-AWII-2024-11-04_143058" src="https://github.com/user-attachments/assets/95dc6e02-1d0c-41f4-94fc-ac94c8956e35">
